### PR TITLE
Fix some warnings and errors in modern Clang and libc++

### DIFF
--- a/lug/detail.hpp
+++ b/lug/detail.hpp
@@ -18,7 +18,7 @@
 #define LUG_DIAGNOSTIC_PUSH_AND_IGNORE \
 _Pragma("GCC diagnostic push") \
 _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
-_Pragma("GCC diagnostic ignored \"-Wlogical-not-parentheses\"")
+_Pragma("GCC diagnostic ignored \"-Wlogical-not-parentheses\"") \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")
 
 #define LUG_DIAGNOSTIC_POP \

--- a/lug/unicode.hpp
+++ b/lug/unicode.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 namespace lug::unicode
 {


### PR DESCRIPTION
Among the changes required to make lug compile with modern Clang and libc++, these are the most straightforward.